### PR TITLE
Retry analysis requests if we fail to send failure messages after failing.

### DIFF
--- a/analysis/src/catalog.js
+++ b/analysis/src/catalog.js
@@ -2,21 +2,6 @@
 
 const Ana = require('./ana_log');
 
-/**
- * @param {Object} obj - The object to strip properties from.
- * @param {Array.<string>} properties - An array of property names to remove.
- */
-function removeProperties(obj, properties) {
-  if (!properties || !obj) return;
-  if (typeof obj === 'object') {
-    for (var prop of properties) {
-      delete obj[prop];
-    }
-    Object.keys(obj).forEach(x => removeProperties(obj[x], properties));
-  } else if (Array.isArray(obj)) {
-    obj.forEach(val => removeProperties(val, properties));
-  }
-}
 
 /**
  * Service for communicating with the catalog servers.
@@ -43,8 +28,7 @@ class Catalog {
   postResponse(data, attributes) {
     return new Promise((resolve, reject) => {
       Ana.log("catalog/postResponse");
-      // omit ridiculously huge (or circular) fields from JSON stringify
-      removeProperties(data, ["scriptElement", "javascriptNode"]);
+
       if (Ana.isDebug()) {
         Ana.log("catalog/postResponse/debug attributes ", JSON.stringify(attributes));
         Ana.log("catalog/postResponse/debug data ", JSON.stringify(data, null, '\t'));

--- a/analysis/src/hydrolysis.js
+++ b/analysis/src/hydrolysis.js
@@ -5,6 +5,22 @@ const hyd = require('hydrolysis');
 const path = require('path');
 
 /**
+ * @param {Object} obj - The object to strip properties from.
+ * @param {Array.<string>} properties - An array of property names to remove.
+ */
+function removeProperties(obj, properties) {
+  if (!properties || !obj) return;
+  if (typeof obj === 'object') {
+    for (var prop of properties) {
+      delete obj[prop];
+    }
+    Object.keys(obj).forEach(x => removeProperties(obj[x], properties));
+  } else if (Array.isArray(obj)) {
+    obj.forEach(val => removeProperties(val, properties));
+  }
+}
+
+/**
  * Service for running Hydrolysis on the local machine.
  */
 class Hydrolysis {
@@ -45,13 +61,8 @@ class Hydrolysis {
 
               Ana.debug("Got elements and behaviors");
 
-              // Strip useless (bloated) parts from the elements.
-              elements.forEach(element => {
-                element.scriptElement = undefined;
-                element.properties && element.properties.forEach(property => {
-                  property.javascriptNode = undefined;
-                });
-              });
+              // Strip ridiculously huge (or circular) fields from elements.
+              removeProperties(elements, ["scriptElement", "javascriptNode"]);
               Ana.debug("Filtered elements");
 
               // Get the element names that were in the folder.


### PR DESCRIPTION
also...
- change status(x).send() to sendStatus(x), cause that's a thing
- move property filtering to hydrolysis where it belongs (and keep the more comprehensive hierarchy filtering)