### PR TITLE
Add log output to non-transient failure responses

### DIFF
--- a/analysis/package.json
+++ b/analysis/package.json
@@ -11,7 +11,8 @@
     "command-line-args": "3.0.1",
     "express": "4.13.4",
     "hydrolysis": "1.24.1",
-    "lockfile": "1.0.1"
+    "lockfile": "1.0.1",
+    "stream-buffers": "3.0.1"
   },
   "engines": {
     "node": "4.4.5"

--- a/analysis/src/ana_log.js
+++ b/analysis/src/ana_log.js
@@ -1,6 +1,22 @@
 'use strict';
 
+var Console = require('console').Console;
+var streamBuffers = require('stream-buffers');
+
 var debug = false;
+
+var logBuffer;
+var bufferedConsole;
+
+function initConsole() {
+  logBuffer = new streamBuffers.WritableStreamBuffer({
+      initialSize: (100 * 1024),
+      incrementAmount: (10 * 1024)
+  });
+  bufferedConsole = new Console(logBuffer, logBuffer);
+}
+
+initConsole();
 
 class Ana {
   static success(counterPath) {
@@ -8,8 +24,10 @@ class Ana {
     if (arguments.length > 1) {
       var logArgs = [path].concat(Array.prototype.slice.call(arguments, 1));
       console.log.apply(null, logArgs);
+      bufferedConsole.log.apply(null, logArgs);
     } else {
       console.log(path);
+      bufferedConsole.log(path);
     }
   }
   static fail(counterPath) {
@@ -17,23 +35,33 @@ class Ana {
     if (arguments.length > 1) {
       var logArgs = [path].concat(Array.prototype.slice.call(arguments, 1));
       console.log.apply(null, logArgs);
+      bufferedConsole.log.apply(null, logArgs);
     } else {
       console.log(path);
+      bufferedConsole.log(path);
     }
   }
   static debug() {
     if (debug) {
+      // Don't buffer debug logs
       console.log.apply(null, arguments);
     }
   }
   static log() {
     console.log.apply(null, arguments);
+    bufferedConsole.log.apply(null, arguments);
   }
   static isDebug() {
     return debug;
   }
   static enableDebug() {
     debug = true;
+  }
+  static newBuffer() {
+    initConsole();
+  }
+  static readBuffer() {
+    return logBuffer.getContentsAsString('utf8');
   }
 }
 

--- a/analysis/src/main.js
+++ b/analysis/src/main.js
@@ -54,6 +54,7 @@ function processTasks() {
   var locky = new Date().toString() + ".lock";
 
   app.get('/task/analyze/:owner/:repo/:version/:sha*?', (req, res) => {
+    Ana.newBuffer();
     var attributes = {
       owner: req.params.owner,
       repo: req.params.repo,
@@ -92,6 +93,7 @@ function processTasks() {
         } else {
           Ana.fail("main/processTasks");
           attributes.error = "true";
+          error.consoleOutput = Ana.readBuffer();
           catalog.postResponse(error, attributes)
               .then(() => res.sendStatus(200))
               .catch(() => res.sendStatus(500));


### PR DESCRIPTION
I'm not 100% sure that I like this approach (it's really not multi-operation safe, although neither is bower...) but it seems to work.

The error blob will look similar to that shown below (this is the I-can't-find-the-sha-you-gave-me output):
```
catalog/postResponse/debug data  {
	"retry": false,
	"error": {
		"code": "ENORESTARGET",
		"details": "Available tags: v0.9.0, v0.9.1, v0.9.2, v0.9.3, v0.9.4, v1.0.0, v1.0.1, v1.0.2, v1.0.4, v1.0.5, v1.0.6, v1.1.0, v1.1.1, v1.2.0, v1.2.1, v1.2.2, v1.2.3, v1.2.4, v1.2.5, v1.2.6, v1.2.7\nAvailable branches: 2.0-preview, add-polylint, demo-dropdown, issue-35, issue-79-dialog, master",
		"data": {
			"endpoint": {
				"name": "",
				"source": "PolymerElements/paper-dialog-behavior",
				"target": "eacabc02ab06e03f17d26e0b777b102bdc2ed55aaa6"
			},
			"resolver": {
				"name": "paper-dialog-behavior",
				"source": "git://github.com/PolymerElements/paper-dialog-behavior.git",
				"target": "eacabc02ab06e03f17d26e0b777b102bdc2ed55aaa6"
			}
		}
	},
	"consoleOutput": "analysis/processNextTask {\"owner\":\"PolymerElements\",\"repo\":\"paper-dialog-behavior\",\"version\":\"v1.2.7\",\"sha\":\"eacabc02ab06e03f17d26e0b777b102bdc2ed55aaa6\"}\nbower/prune\nbower/prune/success\nbower/install PolymerElements/paper-dialog-behavior#eacabc02ab06e03f17d26e0b777b102bdc2ed55aaa6\nbower/install/fail PolymerElements/paper-dialog-behavior#eacabc02ab06e03f17d26e0b777b102bdc2ed55aaa6\nanalysis/processNextTask/fail {\"owner\":\"PolymerElements\",\"repo\":\"paper-dialog-behavior\",\"version\":\"v1.2.7\",\"sha\":\"eacabc02ab06e03f17d26e0b777b102bdc2ed55aaa6\"} { retry: false,\n  error: \n   { Error: Tag/branch eacabc02ab06e03f17d26e0b777b102bdc2ed55aaa6 does not exist\n       at createError (/Users/andymutton/dev/customelementsv2/analysis/node_modules/bower/lib/util/createError.js:4:15)\n       at /Users/andymutton/dev/customelementsv2/analysis/node_modules/bower/lib/core/resolvers/GitResolver.js:183:15\n       at /Users/andymutton/dev/customelementsv2/analysis/node_modules/bower/lib/node_modules/q/q.js:1229:26\n       at _fulfilled (/Users/andymutton/dev/customelementsv2/analysis/node_modules/bower/lib/node_modules/q/q.js:834:54)\n       at self.promiseDispatch.done (/Users/andymutton/dev/customelementsv2/analysis/node_modules/bower/lib/node_modules/q/q.js:863:30)\n       at Promise.promise.promiseDispatch (/Users/andymutton/dev/customelementsv2/analysis/node_modules/bower/lib/node_modules/q/q.js:796:13)\n       at /Users/andymutton/dev/customelementsv2/analysis/node_modules/bower/lib/node_modules/q/q.js:556:49\n       at runSingle (/Users/andymutton/dev/customelementsv2/analysis/node_modules/bower/lib/node_modules/q/q.js:137:13)\n       at flush (/Users/andymutton/dev/customelementsv2/analysis/node_modules/bower/lib/node_modules/q/q.js:125:13)\n       at _combinedTickCallback (internal/process/next_tick.js:67:7)\n       at process._tickCallback (internal/process/next_tick.js:98:9)\n     code: 'ENORESTARGET',\n     details: 'Available tags: v0.9.0, v0.9.1, v0.9.2, v0.9.3, v0.9.4, v1.0.0, v1.0.1, v1.0.2, v1.0.4, v1.0.5, v1.0.6, v1.1.0, v1.1.1, v1.2.0, v1.2.1, v1.2.2, v1.2.3, v1.2.4, v1.2.5, v1.2.6, v1.2.7\\nAvailable branches: 2.0-preview, add-polylint, demo-dropdown, issue-35, issue-79-dialog, master',\n     data: { endpoint: [Object], resolver: [Object] } } }\nmain/processTasks/fail\n"
}
```