### PR TITLE
Dedupe demos and show demos above API docs in some cases

### DIFF
--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -550,11 +550,15 @@
           <div id="sidebar-nav" class="box loader" role="navigation" collapse$="[[_shouldCollapseNav(bundledElements)]]" loading$="[[_docsPending(_docsLoading, docs)]]">
             <a href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]">[[_readmeLabel(bundledElements)]]</a>
 
+            <template is="dom-repeat" items="[[dupedDemos]]" as="demo">
+              <a class="demo-link" href="[[route.prefix]]/[[owner]]/[[repo]]/[[data.version]]/demo/[[demo.path]]" on-tap="_demoClicked"><span>[[demo.desc]]</span></a>
+            </template>
+
             <template is="dom-repeat" items="[[bundledElements]]" as="element">
               <a class="api-link" href="[[route.prefix]]/[[owner]]/[[repo]][[versionRoute]]/[[element.is]]"><span>[[element.is]]</span></a>
 
               <div class="element-demos" role="navigation" aria-label$="[[element.is]] demos">
-                <template is="dom-repeat" items=[[element.demos]] as="demo">
+                <template is="dom-repeat" items="[[element.demos]]" as="demo">
                   <a class="demo-link" href="[[route.prefix]]/[[owner]]/[[repo]]/[[data.version]]/demo/[[demo.path]]" on-tap="_demoClicked"><span>[[demo.desc]]</span></a>
                 </template>
               </div>
@@ -564,7 +568,7 @@
               <a class="api-link" href="[[route.prefix]]/[[owner]]/[[repo]]/[[data.version]]/[[behavior.is]]"><span>[[behavior.is]]</span></a>
 
               <div class="element-demos">
-                <template is="dom-repeat" items=[[behavior.demos]] as="demo">
+                <template is="dom-repeat" items="[[behavior.demos]]" as="demo">
                   <a class="demo-link" href="[[route.prefix]]/[[owner]]/[[repo]]/[[data.version]]/demo/[[demo.path]]" on-tap="_demoClicked"><span>[[demo.desc]]</span></a>
                 </template>
               </div>
@@ -683,6 +687,7 @@
         delete this.descriptor;
         this.bundledElements = [];
         this.bundledBehaviors = [];
+        this.dupedDemos = [];
         this.collections = null;
         this.docs = null;
       },
@@ -706,6 +711,8 @@
 
         if (split.length && split[0].indexOf('demo') != -1) {
           split.shift();
+          if (split[split.length - 1] == '')
+            split[split.length - 1] = 'index.html';
           this.demo = split.join('/');
           split = [];
         }
@@ -848,7 +855,44 @@
           return;
         this.bundledElements = this._elements();
         this.bundledBehaviors = this._behaviors();
+        if (!this.dupedDemos.length)
+          this.dupedDemos = this._demos();
         this.descriptor = this.docs.content.elementsByTagName[this.subElement] || this.docs.content.behaviorsByName[this.subElement];
+      },
+
+      _demos: function() {
+        var demoCounts = {};
+        var dupedDemos = [];
+
+        function countDemos(element) {
+          element.demos.forEach(function(demo) {
+            demoCounts[demo.path] = (demoCounts[demo.path] || 0) + 1;
+          });
+        }
+
+        function dedupeDemos(element) {
+          for (var j = 0; j < element.demos.length; j++) {
+            var demo = element.demos[j];
+            if (demoCounts[demo.path] > 1) {
+              dupedDemos.push(element.demos.splice(j, 1)[0]);
+              demoCounts[demo.path] = -1;
+            } else if (demoCounts[demo.path] == -1) {
+              element.demos.splice(j, 1);
+            }
+          }
+        }
+
+        this.bundledElements.forEach(countDemos);
+        this.bundledBehaviors.forEach(countDemos);
+
+        // Show single demos at the top by marking them as a dupe.
+        var paths = Object.keys(demoCounts);
+        if (paths.length == 1)
+          demoCounts[paths[0]] = 2;
+
+        this.bundledElements.forEach(dedupeDemos);
+        this.bundledBehaviors.forEach(dedupeDemos);
+        return dupedDemos;
       },
 
       _dependencies: function() {


### PR DESCRIPTION
 - Shows demos above API docs if there's only one demo.
 - Shows duped demos above API docs.
 - Fixes #442 