### PR TITLE
Fix markdown styling

### DIFF
--- a/client/src/catalog-api-doc.html
+++ b/client/src/catalog-api-doc.html
@@ -2,7 +2,7 @@
 
 <link rel="import" href="catalog-api-property.html">
 <link rel="import" href="catalog-styles.html">
-<link rel="import" href="markdown-render.html">
+<link rel="import" href="mark-down.html">
 
 <dom-module id="catalog-api-doc">
   <template>
@@ -45,53 +45,6 @@
         padding: 4px 0;
       }
 
-      #summary .markdown-html table {
-        font-size: 14px;
-        background-color: hsl(0, 0%, 95%);
-        border-collapse: collapse;
-        margin: 12px 0;
-        width: 100%;
-      }
-
-      #summary .markdown-html tr {
-        padding: 0 18px;
-      }
-
-      #summary .markdown-html th {
-        font-weight: bold;
-      }
-
-      #summary .markdown-html td,
-      #summary .markdown-html th {
-        padding: 6px 12px;
-      }
-
-      #summary .markdown-html td:first-child,
-      #summary .markdown-html th:first-child {
-        padding-left: 24px;
-      }
-
-      #summary .markdown-html td:last-child,
-      #summary .markdown-html th:last-child {
-        padding-right: 24px;
-      }
-
-      #summary .markdown-html td:first-child > code {
-        color: black;
-        font-weight: bold;
-      }
-
-      #summary .markdown-html p {
-        padding: 0;
-      }
-
-      #summary .markdown-html a {
-        background: none;
-        color: #536dfe; /*var(--paper-indigo-a200);*/
-        font-weight: 500;
-        text-decoration: none;
-      }
-
       /* Property Sections */
 
       .card {
@@ -109,11 +62,11 @@
       }
 
       nav {
-        border-bottom: 1px solid #eeeeee; /*var(--paper-grey-200)*/
+        border-bottom: 1px solid hsl(0, 0%, 95%);
       }
 
       catalog-api-property {
-        background: #eeeeee; /*var(--paper-grey-200)*/
+        background: hsl(0, 0%, 95%);
       }
 
       catalog-api-property:first-of-type {
@@ -143,7 +96,7 @@
     </style>
 
     <section id="summary" class="card" hidden$="[[!descriptor.desc]]">
-      <markdown-render markdown="{{descriptor.desc}}" class="markdown-html"></markdown-render>
+      <mark-down markdown="{{descriptor.desc}}" class="markdown-html"></mark-down>
     </section>
 
     <nav id="api">

--- a/client/src/catalog-api-property.html
+++ b/client/src/catalog-api-property.html
@@ -1,6 +1,7 @@
 
 <link rel="import" href="../bower_components/polymer/polymer.html">
-<link rel="import" href="../bower_components/marked-element/marked-element.html">
+
+<link rel="import" href="mark-down.html">
 
 <dom-module id="catalog-api-property">
   <template>
@@ -198,21 +199,18 @@
           <li hidden$="{{!item.type}}">
             <span class="name">{{item.name}}</span>
             <span class="type">{{item.type}}</span>
-            <marked-element markdown="{{item.desc}}">
-              <div class="markdown-html"></div>
-            </marked-element>
+            <mark-down markdown="{{item.desc}}" class="markdown-html">
+            </mark-down>
           </li>
         </template>
         <li class="return" hidden$="{{!descriptor.return}}">Returns
           <span class="type">{{descriptor.return.type}}</span>
-          <marked-element markdown="{{descriptor.return.desc}}">
-            <div class="markdown-html"></div>
-          </marked-element>
+          <mark-down markdown="{{descriptor.return.desc}}" class="markdown-html">
+          </mark-down>
         </li>
       </ol>
-      <marked-element id="desc" markdown="{{descriptor.desc}}" hidden$="{{!descriptor.desc}}">
-        <div class="markdown-html"></div>
-      </marked-element>
+      <mark-down id="desc" markdown="{{descriptor.desc}}" class="markdown-html" hidden$="{{!descriptor.desc}}">
+      </mark-down>
     </div>
   </template>
 

--- a/client/src/catalog-api-property.html
+++ b/client/src/catalog-api-property.html
@@ -134,7 +134,7 @@
         padding-bottom: 8px;
       }
 
-      marked-element {
+      mark-down {
         display: inline-block;
       }
 

--- a/client/src/mark-down.html
+++ b/client/src/mark-down.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="catalog-styles.html">
 <link rel="import" href="catalog-syntax-styles.html">
 
-<dom-module id="markdown-render">
+<dom-module id="mark-down">
   <template>
     <style include="catalog-styles"></style>
     <style include="catalog-syntax-styles"></style>
@@ -23,6 +23,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         background: inherit;
         color: inherit;
         padding: 0;
+      }
+
+
+      table {
+        font-size: 14px;
+        background-color: hsl(0, 0%, 95%);
+        border-collapse: collapse;
+        margin: 12px 0;
+        width: 100%;
+      }
+
+      tr {
+        padding: 0 18px;
+      }
+
+      th {
+        font-weight: bold;
+      }
+
+      td,
+      th {
+        padding: 6px 12px;
+      }
+
+      td:first-child,
+      th:first-child {
+        padding-left: 24px;
+      }
+
+      td:last-child,
+      th:last-child {
+        padding-right: 24px;
+      }
+
+      td:first-child > code {
+        color: black;
+        font-weight: bold;
       }
     </style>
 
@@ -35,7 +72,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   Polymer({
 
-    is: 'markdown-render',
+    is: 'mark-down',
 
     properties: {
       /**

--- a/client/src/syntax-highlighter.html
+++ b/client/src/syntax-highlighter.html
@@ -42,7 +42,7 @@
 
     /**
      * Detect language of the element. Elements can set a 'lang' attribute.
-     * Auto-detects markdown-render language.
+     * Auto-detects mark-down language.
      * @param {!Element} element - DOM element to highlight
      * @return {String} - language
      */


### PR DESCRIPTION
Some styles were lost when transferring away from `marked-element`.

This removes `marked-element` from the project. This makes no style changes here and needs to be cleaned up at some point.