### PR TITLE
Allow git uris in more than leaf nodes of the dependency graph.

### DIFF
--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -171,20 +171,27 @@ class Bower {
           logEntry.data.pkgMeta._resolution) {
           var owner = "";
           var repo = "";
+          var sha = "";
           // Our package strings look like "Owner/Repo#1.2.3"
-          if (ownerPackageVersionString.includes("/")) {
+          if (ownerPackageVersionString.includes("/") && !ownerPackageVersionString.includes("git://")) {
             owner = ownerPackageVersionString;
             repo = owner.substring(owner.lastIndexOf("/") + 1, owner.lastIndexOf("#"));
             owner = owner.substring(0, owner.lastIndexOf("/"));
+            if (ownerPackageVersionString.includes("#")) {
+              sha = ownerPackageVersionString.substring(ownerPackageVersionString.lastIndexOf("#"));
+            }
           } else {
             // These uris look like "git://github.com/Owner/Repo.git"
             owner = url.parse(logEntry.data.resolver.source).pathname;
             repo = owner.substring(owner.lastIndexOf("/") + 1, owner.lastIndexOf("."));
             owner = owner.substring(1 /* skip leading slash */, owner.lastIndexOf("/"));
+            if (logEntry.data.resolver.source.includes("#")) {
+              sha = logEntry.data.resolver.source.substring(logEntry.data.resolver.source.lastIndexOf("#"));
+            }
           }
           metadata = {
             name: logEntry.data.pkgMeta.name,
-            version: logEntry.data.pkgMeta._resolution.tag,
+            version: logEntry.data.pkgMeta._resolution.tag ? logEntry.data.pkgMeta._resolution.tag : sha.replace("#", ""),
             owner: owner,
             repo: repo
           };


### PR DESCRIPTION
Also propagate sha versions into the dependency metadata if required.