### PR TITLE
Various mobile fixes

### DIFF
--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -23,6 +23,7 @@
         font-family: 'Source Sans Pro', sans-serif;
         font-size: 16px;
         line-height: 24px;
+        word-wrap: break-word;
         padding-top: 160px;
         color: var(--theme-font-color);
         --bg-gradient: linear-gradient(to bottom, #F3F4F5 160px, white 50vh);

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -263,7 +263,7 @@
         width: 10px;
         position: absolute;
         top: 0px;
-        right: -10px;
+        right: -9px;
         height: 100%;
         background: white;
         -webkit-clip-path: polygon(100% 0%, 0% 0%, 0% 100%, 100% 100%, 100% calc(100% - 2px), 0 50%, 100% 2px);

--- a/client/src/catalog-item.html
+++ b/client/src/catalog-item.html
@@ -41,6 +41,11 @@
         line-height: 24px;
       }
 
+      #description {
+        max-height: 94px;
+        overflow: hidden;
+      }
+
       #author a:first-child {
         color: inherit;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5299,9 +5299,9 @@ ternary-stream@^2.0.0:
     merge-stream "^1.0.0"
     through2 "^2.0.0"
 
-"test-fixture@github:polymerelements/test-fixture":
+test-fixture@PolymerElements/test-fixture:
   version "1.1.1"
-  resolved "https://codeload.github.com/polymerelements/test-fixture/tar.gz/05514d6f32ade6fe54de5b242bbb43ea9dcff3c0"
+  resolved "https://codeload.github.com/PolymerElements/test-fixture/tar.gz/05514d6f32ade6fe54de5b242bbb43ea9dcff3c0"
 
 test-value@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Fixes #578 
Fixes overlapping repo contents border on mobile
Forced wrapping on mobile so viewport doesn't scroll horizontally in cases like long urls which have no work breaks.
