### PR TITLE
Lowercase packages when calling info from bower

### DIFF
--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -154,7 +154,7 @@ class Bower {
     return new Promise(resolve => {
       var metadata = null;
       bower.commands.info(
-        ownerPackageVersionString,
+        ownerPackageVersionString.toLowerCase(),
         undefined /* property */,
         {
           offline: offline


### PR DESCRIPTION
Consistent package casing seems to enable it to make the right matches in its cache.

Fixes #557 