### PR TITLE
Cached element load time from 500ms to 4ms

### DIFF
--- a/client/service-worker-runtime.js
+++ b/client/service-worker-runtime.js
@@ -6,7 +6,7 @@ toolbox.router.get(/\/api\/search\/.*/, toolbox.networkFirst, {
   successResponses: /^0|[123]\d\d$/,
 });
 
-toolbox.router.get(/\/api\/.*/, toolbox.networkFirst, {
+toolbox.router.get(/\/api\/.*/, toolbox.fastest, {
   cache: {
     maxEntries:1000,
     name: "api-cache",

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -1042,7 +1042,7 @@
         if (!window.localStorage.starredRepos)
           return false;
         var starred = JSON.parse(window.localStorage.starredRepos);
-        return starred.indexOf(this.owner + '/' + this.repo) != -1;
+        return this._inflightStar || starred.indexOf(this.owner + '/' + this.repo) != -1;
       },
 
       _setStarred: function(increment) {
@@ -1061,14 +1061,16 @@
           return;
 
         // Pre-emptively set starred, so UI updates while the request is in flight.
-        this._repoStarred = true;
+        this._inflightStar = true;
+        this._repoStarred = this._isStarred();
 
         var xhr = new XMLHttpRequest();
         xhr.addEventListener('load', function(event) {
+          this._inflightStar = false;
           this._setStarred(event.target.status == 204);
         }.bind(this));
         xhr.addEventListener('error', function() {
-          this._repoStarred = false;
+          this._inflightStar = false;
         }.bind(this));
 
         xhr.open('POST', this.baseUrls.api + '/api/star/' + this.owner + '/' + this.repo + '?code=' + this.queryParams.code);

--- a/client/src/catalog-element.html
+++ b/client/src/catalog-element.html
@@ -1057,12 +1057,18 @@
       },
 
       _starRepo: function() {
-        if (!this.queryParams || !this.queryParams.code)
+        if (!this.queryParams || !this.queryParams.code || this._isStarred())
           return;
+
+        // Pre-emptively set starred, so UI updates while the request is in flight.
+        this._repoStarred = true;
 
         var xhr = new XMLHttpRequest();
         xhr.addEventListener('load', function(event) {
           this._setStarred(event.target.status == 204);
+        }.bind(this));
+        xhr.addEventListener('error', function() {
+          this._repoStarred = false;
         }.bind(this));
 
         xhr.open('POST', this.baseUrls.api + '/api/star/' + this.owner + '/' + this.repo + '?code=' + this.queryParams.code);


### PR DESCRIPTION
 * Use fastest for API requests, still fires off a network request.
 * Prevent firing off a second request if the page is reloaded.
 * Show starred while in-flight starring request.