### PR TITLE
Don't lowercase git uris when performing the info call

### DIFF
--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -163,7 +163,7 @@ class Bower {
     return new Promise(resolve => {
       var metadata = null;
       bower.commands.info(
-        ownerPackageVersionString.toLowerCase(),
+        ownerPackageVersionString.indexOf("git://") == 0 ? ownerPackageVersionString : ownerPackageVersionString.toLowerCase(),
         undefined /* property */,
         {
           offline: offline


### PR DESCRIPTION
This allows the info call to return info, rather than a cache miss.

We're not _really_ happy with this. It should fix another one of the missing dependency problems, but it's leaning very heavily into the hack world.

Rewriting this code to work differently is starting to seem a sensible approach, although what would be more sensible is probably waiting until we move from hydrolysis to analysis and bower to npm.