### PR TITLE
Add example code to show other-element import

### DIFF
--- a/client/src/catalog-publish.html
+++ b/client/src/catalog-publish.html
@@ -118,6 +118,7 @@
 ```
 &lt;custom-element-demo&gt;
   &lt;template&gt;
+    &lt;link rel="import" href="../other-element/other-element.html"&gt;
     &lt;link rel="import" href="my-element.html"&gt;
     &lt;next-code-block&gt;&lt;/next-code-block&gt;
   &lt;/template&gt;
@@ -125,6 +126,7 @@
 ```
 --&gt;
 ```
+&lt;other-element&gt;&lt;/other-element&gt;
 &lt;my-element&gt;&lt;/my-element&gt;
 ```</pre>
 


### PR DESCRIPTION
It wasn't initially clear to me that I could import other elements that were dependencies in the inline demo. Even though it is answered in the FAQ below the example code, I think it would be much more straightforward for people to see how to import other elements in their demo directly in the example code.

If you think this isn't as simple as not showing it and may confuse people here are some alternatives:

1.  show 2 example code blocks, one with importing other elements and one without
2. show example code in the FAQ section's answer to show how to import sibling elements.

I'm not sure what percentage of elements require other elements for their demos but would imagine that would be the deciding factor.

Hope this helps.