### PR TITLE
Fix rendered markdown in catalog publish

### DIFF
--- a/client/src/catalog-publish.html
+++ b/client/src/catalog-publish.html
@@ -131,6 +131,7 @@
 ```</pre>
 
         <p>The Github rendered markdown is:</p>	
+        <pre lang="html">&lt;other-element&gt;&lt;/other-element&gt;</pre>
         <pre lang="html">&lt;my-element&gt;&lt;/my-element&gt;</pre>
 	
         <p>Best practices:</p>


### PR DESCRIPTION
In #661, forgot to update the rendered markdown. This should fix that.