### PR TITLE
Always request dependencies in online mode (slower but more reliable?)…

### DIFF
--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -164,7 +164,7 @@ class Bower {
   }
 
   static infoPromise(ownerPackageVersionString, offline, pairBuddy) {
-    let ownerRepo = function(resolverSource) {
+    var ownerRepo = function(resolverSource) {
       var source = url.parse(resolverSource);
       if (source.hostname != 'github.com')
         return;

--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -149,14 +149,13 @@ class Bower {
         // pairBuddy collects the errors from each install.
         // We use it to determine whether a genuine error occured (two failures).
         var pairBuddy = [];
-        var promiseOne;
+        var keyPlusPackageToProcess;
         if (packageToProcess.indexOf('#') == 0) {
-          promiseOne = key + packageToProcess;
+          keyPlusPackageToProcess = key + packageToProcess;
         } else {
-          promiseOne = key + "#" + packageToProcess;
+          keyPlusPackageToProcess = key + "#" + packageToProcess;
         }
-        var promiseTwo = packageToProcess;
-        promises.push(Bower.dependencies(promiseOne, processed, offline, pairBuddy));
+        promises.push(Bower.dependencies(keyPlusPackageToProcess, processed, offline, pairBuddy));
         promises.push(Bower.dependencies(packageToProcess, processed, offline, pairBuddy));
       });
 

--- a/analysis/src/bower.js
+++ b/analysis/src/bower.js
@@ -167,7 +167,7 @@ class Bower {
     var ownerRepo = function(resolverSource) {
       var source = url.parse(resolverSource);
       if (source.hostname != 'github.com')
-        return;
+        return null;
 
       var parts = source.pathname.substring(1).split('/', 2);
       var owner = parts[0];


### PR DESCRIPTION
... and use not-cached results if 'cached' aren't available. Should only be triggered for dependencies against branches.