### PR TITLE
Preserve analysis data when reanalyzing. Add analysis queue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
 before_install:
 - mkdir -p lib
 install:
+- sudo apt-get install default-jre
 - npm install -g yarn@0.16
 - npm install -g bower
 - yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ env:
 before_install:
 - mkdir -p lib
 install:
-- sudo apt-get install default-jre
 - npm install -g yarn@0.16
 - npm install -g bower
 - yarn

--- a/queue.yaml
+++ b/queue.yaml
@@ -2,3 +2,6 @@ queue:
 - name: update
   target: manage
   rate: 20/s
+- name: analysis
+  target: analysis
+  rate: 20/s

--- a/src/manage.py
+++ b/src/manage.py
@@ -312,9 +312,13 @@ class LibraryTask(RequestHandler):
     if self.library.kind == 'collection':
       analysis_sha = sha
     version_key = ndb.Key(Library, self.library.key.id(), Version, tag)
-    Content(id='analysis', parent=version_key, status=Status.pending).put()
+
+    content = Content.get_by_id('analysis', parent=version_key)
+    if content is None:
+      Content(id='analysis', parent=version_key, status=Status.pending).put()
+
     task_url = util.ingest_analysis_task(self.owner, self.repo, tag, analysis_sha)
-    util.new_task(task_url, target='analysis', transactional=transactional)
+    util.new_task(task_url, target='analysis', transactional=transactional, queue_name='analysis')
 
   def trigger_author_ingestion(self):
     if self.library.shallow_ingestion:

--- a/src/manage.py
+++ b/src/manage.py
@@ -314,7 +314,7 @@ class LibraryTask(RequestHandler):
     version_key = ndb.Key(Library, self.library.key.id(), Version, tag)
 
     content = Content.get_by_id('analysis', parent=version_key)
-    if content is None:
+    if content is None or content.status == Status.error:
       Content(id='analysis', parent=version_key, status=Status.pending).put()
 
     task_url = util.ingest_analysis_task(self.owner, self.repo, tag, analysis_sha)

--- a/src/manage_test.py
+++ b/src/manage_test.py
@@ -77,10 +77,35 @@ class UpdateAllTest(ManageTestBase):
 class AnalyzeTest(ManageTestBase):
   def test_analyze(self):
     library_key = Library(id='owner/repo').put()
-    Version(id='v1.1.1', parent=library_key, sha='sha', status='ready').put()
+    version_key = Version(id='v1.1.1', parent=library_key, sha='sha', status='ready').put()
 
     response = self.app.get('/task/analyze/owner/repo', headers={'X-AppEngine-QueueName': 'default'})
     self.assertEqual(response.status_int, 200)
+
+    content = Content.get_by_id('analysis', parent=version_key)
+    self.assertEqual(content.content, None)
+    self.assertEqual(content.status, Status.pending)
+
+    tasks = self.tasks.get_filtered_tasks()
+    self.assertEqual([
+        util.ingest_analysis_task('owner', 'repo', 'v1.1.1'),
+    ], [task.url for task in tasks])
+
+  def test_analyze_leaves_existing_content_when_reanalyzing(self):
+    library_key = Library(id='owner/repo').put()
+    version_key = Version(id='v1.1.1', parent=library_key, sha='sha', status='ready').put()
+
+    content = Content(id='analysis', parent=version_key, status=Status.pending)
+    content.content = 'existing data'
+    content.status = Status.ready
+    content.put()
+
+    response = self.app.get('/task/analyze/owner/repo', headers={'X-AppEngine-QueueName': 'default'})
+    self.assertEqual(response.status_int, 200)
+
+    content = Content.get_by_id('analysis', parent=version_key)
+    self.assertEqual(content.content, 'existing data')
+    self.assertEqual(content.status, Status.ready)
 
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual([
@@ -220,8 +245,8 @@ class UpdateLibraryTest(ManageTestBase):
 
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual([
-        util.ingest_version_task('org', 'repo', 'v3.0.0'),
         util.ingest_analysis_task('org', 'repo', 'v3.0.0'),
+        util.ingest_version_task('org', 'repo', 'v3.0.0'),
     ], [task.url for task in tasks])
 
   def test_update_doesnt_ingest_older_versions(self):
@@ -261,8 +286,8 @@ class UpdateLibraryTest(ManageTestBase):
 
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual([
-        util.ingest_version_task('org', 'repo', 'v3.0.0'),
         util.ingest_analysis_task('org', 'repo', 'v3.0.0'),
+        util.ingest_version_task('org', 'repo', 'v3.0.0'),
     ], [task.url for task in tasks])
 
   def test_update_triggers_version_deletion(self):
@@ -328,8 +353,8 @@ class UpdateLibraryTest(ManageTestBase):
 
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual([
-        util.ingest_version_task('org', 'repo', 'v0.0.2'),
         util.ingest_analysis_task('org', 'repo', 'v0.0.2', 'new-master-sha'),
+        util.ingest_version_task('org', 'repo', 'v0.0.2'),
     ], [task.url for task in tasks])
 
     version = Version.get_by_id('v0.0.2', parent=library_key)
@@ -404,8 +429,8 @@ class IngestLibraryTest(ManageTestBase):
 
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual([
-        util.ingest_version_task('org', 'repo', 'v1.0.0'),
         util.ingest_analysis_task('org', 'repo', 'v1.0.0'),
+        util.ingest_version_task('org', 'repo', 'v1.0.0'),
         util.ensure_author_task('org'),
     ], [task.url for task in tasks])
 
@@ -432,8 +457,8 @@ class IngestLibraryTest(ManageTestBase):
 
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual([
-        util.ingest_version_task('org', 'repo', 'v0.0.1'),
         util.ingest_analysis_task('org', 'repo', 'v0.0.1', 'master-sha'),
+        util.ingest_version_task('org', 'repo', 'v0.0.1'),
         util.ensure_author_task('org'),
     ], [task.url for task in tasks])
 
@@ -490,8 +515,8 @@ class IngestLibraryTest(ManageTestBase):
     tasks = self.tasks.get_filtered_tasks()
     self.assertEqual(len(tasks), 2)
     self.assertEqual([
-        util.ingest_version_task('org', 'repo', 'commit-sha'),
         util.ingest_analysis_task('org', 'repo', 'commit-sha'),
+        util.ingest_version_task('org', 'repo', 'commit-sha'),
     ], [task.url for task in tasks])
 
   def test_ingest_license_fallback(self):


### PR DESCRIPTION
Stops us from clearing analysis info when running analyze-all (which would wipe out all data and then reingest slowly).
Adds a dedicated analysis queue to prevent analysis from starving other processes.