### PR TITLE
Disable local wct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 script:
 - grunt lint
 - python tests.py $HOME/gcloud/google-cloud-sdk
-- xvfb-run wct --skip-plugin sauce
+# - xvfb-run wct --skip-plugin sauce
 - "(cd analysis; npm test)"
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct; fi
 before_deploy:


### PR DESCRIPTION
This is broken across all repos on travis currently. The build on master still runs wct, so this won't pick up failures on PRs but will still pick it up on subsequent builds for now.