### PR TITLE
More obvious inline demos & no down-sizing after load

### DIFF
--- a/client/src/catalog-syntax-styles.html
+++ b/client/src/catalog-syntax-styles.html
@@ -19,13 +19,12 @@
 
       .CodeMirror {
         background: var(--syntax-bg);
-        border-radius: 0 0 4px 4px;
+        border-bottom-right-radius: 4px;
         font-size: 14px;
         font-family: var(--monospace-font);
         color: var(--mono-1);
         line-height: 24px;
         height: auto;
-        border-left: 4px solid var(--theme-blue);
         padding-left: 12px;
       }
 

--- a/client/src/custom-element-demo.html
+++ b/client/src/custom-element-demo.html
@@ -5,10 +5,13 @@
   <link rel="import" type="css" href="../bower_components/github-markdown-css/github-markdown.css">
   <template>
     <style>
+      #container {
+        border-left: 8px solid var(--theme-blue);
+      }
+
       #demoContainer {
         width: 100%;
         overflow: hidden;
-        border-radius: 4px 4px 0 0;
         box-sizing: border-box;
         display: flex;
         justify-content: center;
@@ -131,7 +134,7 @@
 
       #lazyEditor {
         display: none;
-        padding: 16px 20px;
+        padding: 16px 20px 16px 16px;
         color: var(--syntax-fg);
         background: var(--syntax-bg);
         font-size: 14px;
@@ -139,7 +142,7 @@
         line-height: 24px;
         margin: 0;
         white-space: pre;
-        border-radius: 0 0 4px 4px;
+        border-bottom-right-radius: 4px;
         overflow: hidden;
       }
 
@@ -374,12 +377,22 @@
         if (event.data.id != this._id)
           return;
 
+        if (!this._firstShown)
+          this._firstShown = performance.now();
+
+        // Allow resizing when loading but only grow once loaded.
+        if (performance.now() - this._firstShown > 500
+            && this._height
+            && event.data.height < this._height) {
+          return;
+        }
+
         this.$['demo-spinner'].removeAttribute('active');
 
-        event.data.height = Math.max(64, event.data.height);
+        this._height = Math.max(64, event.data.height);
         this.$.demoContainer.classList.add('reveal');
-        this.$.frame.style.height = event.data.height + 'px';
-        this.$.demoContainer.style.height = event.data.height + 'px';
+        this.$.frame.style.height = this._height + 'px';
+        this.$.demoContainer.style.height = this._height + 'px';
       },
 
       _showFirstTimeMessage: function() {

--- a/client/src/custom-element-demo.html
+++ b/client/src/custom-element-demo.html
@@ -381,9 +381,9 @@
           this._firstShown = performance.now();
 
         // Allow resizing when loading but only grow once loaded.
-        if (performance.now() - this._firstShown > 500
-            && this._height
-            && event.data.height < this._height) {
+        if (performance.now() - this._firstShown > 500 &&
+            this._height &&
+            event.data.height < this._height) {
           return;
         }
 

--- a/inline-demo.html
+++ b/inline-demo.html
@@ -6,7 +6,8 @@
   }
 
   body:before {
-    border: 1px solid #ededed;
+    border: 2px solid #ededed;
+    border-left: none;
     border-bottom: none;
     position: absolute;
     content: '';


### PR DESCRIPTION
 * More obvious UI that the snippet and demo are related and not just an image
 * Editor jumps around while editing if the inline demo shrinks, so shrinking is disabled except when loading.

![image](https://cloud.githubusercontent.com/assets/787668/21251850/9631c6d4-c3a5-11e6-8745-213232909bc7.png)
