### PR TITLE
Only allow letters & numbers in prefix generation

### DIFF
--- a/src/manage.py
+++ b/src/manage.py
@@ -712,8 +712,8 @@ class UpdateIndexes(RequestHandler):
         search.TextField(name='bower_description', value=bower.get('description', '')),
         search.TextField(name='bower_keywords', value=' '.join(bower.get('keywords', []))),
         search.TextField(name='prefix_matches', value=' '.join(util.generate_prefixes_from_list(
-            [repo] + util.safesplit(metadata.get('description')) + util.safesplit(bower.get('description')) +
-            repo.replace("_", " ").replace("-", " ").split()))),
+            util.safe_split_strip(metadata.get('description')) + util.safe_split_strip(bower.get('description')) +
+            util.safe_split_strip(repo)))),
     ]
 
     analysis = Content.get_by_id('analysis', parent=version_key)

--- a/src/util.py
+++ b/src/util.py
@@ -157,9 +157,10 @@ def generate_prefixes_from_list(list_of_strings):
       prefixes = prefixes + generate_prefixes(token.lower())
   return list(set(prefixes))
 
-def safesplit(item):
+def safe_split_strip(item):
   if item is None:
     return []
   if not isinstance(item, basestring):
     item = str(item)
+  item = re.sub(r'[^a-zA-Z0-9]+', ' ', item)
   return item.split()

--- a/src/util_test.py
+++ b/src/util_test.py
@@ -31,5 +31,9 @@ class InlineDemoTransformTest(unittest.TestCase):
     self.assertEqual(util.generate_prefixes_from_list(['ThisIsWord', 'moon']),
                      ['thisiswo', 'thisiswor', 'this', 'thisisw', 'wor', 'thisi', 'thisis', 'moo', 'thi'])
 
+  def test_generate_prefixes_split(self):
+    self.assertEqual(sorted(util.generate_prefixes_from_list(util.safe_split_strip('material-toggle/button'))),
+                     ['but', 'butt', 'butto', 'mat', 'mate', 'mater', 'materi', 'materia', 'tog', 'togg', 'toggl'])
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Improves #713 
This means we'll only generate prefixes for words and not conjugate words. Generating too many prefixes degrades search ranking quality by allowing unexpected bump in rank of some strings, since it matches many more times.