### PR TITLE
Fix "Take Me Back" when ad-blocker enabled

### DIFF
--- a/client/src/catalog-app.html
+++ b/client/src/catalog-app.html
@@ -765,18 +765,25 @@
       },
 
       _optOut: function() {
+        this._navigated = false;
         function navigate() {
-          window.location.href = 'https://elements.polymer-project.org?redirect=';
+          if (!this._navigated) {
+            this._navigated = true;
+            window.location.href = 'https://elements.polymer-project.org?redirect=';
+          }
         }
 
         /* global ga */
         if (window.ga) {
+          clearTimeout(this._optOutTimerId);
+          this._optOutTimerId = setTimeout(navigate.bind(this), 500);
+
           ga('send', 'event', {
             eventCategory: 'Optout',
             eventAction: 'Toast',
             eventLabel: 'Polymer Elements redirect',
             transport: 'beacon',
-            hitCallback: navigate,
+            hitCallback: navigate.bind(this),
           });
         } else {
           navigate();


### PR DESCRIPTION
When AdBlock is enabled, it prevents the `ga` script from executing
the `hitCallback`, required to actually navigate back to the classic
Polymer Elements catalog.

This patch follows the Google Analytics guide's recommendation of
using `setTimeout()` to ensure the execution of the `ga` callback.
https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#handling_timeouts

Fixes #728